### PR TITLE
Add manim scene for counting lines through four points

### DIFF
--- a/Manim-code/middle-school-code/Ver1.1/count_lines.py
+++ b/Manim-code/middle-school-code/Ver1.1/count_lines.py
@@ -1,0 +1,141 @@
+from manim import *
+import numpy as np
+
+MARGIN = 0.06
+GAP = 0.04
+LEFT_RATIO = 0.55
+RIGHT_RATIO = 0.45
+DEBUG = False
+
+forbid_tokens = ["i", "\\mathrm{i}", "\\sqrt{-}", "복소수", "\\sin", "\\cos", "\\tan", "미분", "적분", "행렬", "벡터"]
+
+def SafeMathTex(tex):
+    for token in forbid_tokens:
+        if token in tex:
+            raise ValueError(f"Forbidden token detected: {token}")
+    return MathTex(tex)
+
+class LayoutGuard:
+    @staticmethod
+    def ensure_no_overlap(scene, items, bounds_rect, min_scale=0.7, step_shift=0.15):
+        for m in items:
+            bbox = m.get_bounding_box()
+            rbb = bounds_rect.get_bounding_box()
+            dx, dy = 0, 0
+            if bbox[0][0] < rbb[0][0]:
+                dx = rbb[0][0] - bbox[0][0] + 0.02
+            if bbox[2][0] > rbb[2][0]:
+                dx = rbb[2][0] - bbox[2][0] - 0.02
+            if bbox[0][1] < rbb[0][1]:
+                dy = rbb[0][1] - bbox[0][1] + 0.02
+            if bbox[2][1] > rbb[2][1]:
+                dy = rbb[2][1] - bbox[2][1] - 0.02
+            if dx or dy:
+                m.shift(np.array([dx, dy, 0]))
+        def overlap(a, b):
+            Ab, Bb = a.get_bounding_box(), b.get_bounding_box()
+            return not (Ab[2][0] < Bb[0][0] or Bb[2][0] < Ab[0][0] or Ab[2][1] < Bb[0][1] or Bb[2][1] < Ab[0][1])
+        for i in range(len(items)):
+            for j in range(i + 1, len(items)):
+                a, b = items[i], items[j]
+                tries = 0
+                while overlap(a, b) and tries < 6:
+                    for m in (a, b):
+                        if m.width > bounds_rect.width * 0.9 and m.get_scale() > min_scale:
+                            m.scale(0.9)
+                    b.shift(RIGHT * step_shift + DOWN * step_shift)
+                    tries += 1
+
+class RollingBoard(VGroup):
+    def __init__(self, width, max_lines=3, line_gap=0.15, **kwargs):
+        super().__init__(**kwargs)
+        self.width = width
+        self.max_lines = max_lines
+        self.line_gap = line_gap
+        self.lines = []
+
+    def add_line(self, scene, mobj):
+        mobj.scale_to_fit_width(self.width)
+        if self.lines:
+            lowest = self.lines[-1]
+            mobj.next_to(lowest, DOWN, buff=self.line_gap).align_to(lowest, LEFT)
+        else:
+            mobj.to_edge(DOWN, buff=0.5).to_edge(RIGHT, buff=0.5)
+        self.lines.append(mobj)
+        scene.add(mobj)
+        if len(self.lines) > self.max_lines:
+            top = self.lines.pop(0)
+            scene.play(FadeOut(top, shift=UP * 0.2), run_time=0.3)
+            for k, line in enumerate(self.lines):
+                if k == 0:
+                    continue
+                line.next_to(self.lines[k - 1], UP, buff=self.line_gap).align_to(self.lines[k - 1], LEFT)
+
+def reserve_panels(scene):
+    frame = scene.camera.frame
+    W, H = frame.get_width(), frame.get_height()
+    inner_w = W * (1 - 2 * MARGIN - GAP)
+    left_w = inner_w * LEFT_RATIO
+    right_w = inner_w * RIGHT_RATIO
+    left_box = Rectangle(width=left_w, height=H * (1 - 2 * MARGIN)).move_to(LEFT * (GAP / 2 * W) + LEFT * (right_w / 2)).shift(RIGHT * (W * MARGIN))
+    right_box = Rectangle(width=right_w, height=H * (1 - 2 * MARGIN)).to_edge(RIGHT, buff=W * MARGIN)
+    if DEBUG:
+        for r, color in [(left_box, YELLOW), (right_box, BLUE)]:
+            r.set_stroke(color, 1).set_fill(opacity=0)
+            scene.add(r.copy())
+    return left_box, right_box
+
+class CountLines(Scene):
+    def construct(self):
+        left_box, right_box = reserve_panels(self)
+        board = RollingBoard(width=right_box.width * 0.95, max_lines=3)
+
+        # Left diagram
+        line = Line(left_box.get_left() + RIGHT * 0.1 + DOWN * 0.1,
+                    left_box.get_right() + LEFT * 0.1 + UP * 0.1)
+        A = Dot(line.point_from_proportion(0.2))
+        B = Dot(line.point_from_proportion(0.5))
+        C = Dot(line.point_from_proportion(0.8))
+        P = Dot(A.get_center() + UP * 1.5)
+        labels = VGroup(
+            MathTex("A").next_to(A, UP, buff=0.1),
+            MathTex("B").next_to(B, DOWN, buff=0.1),
+            MathTex("C").next_to(C, DOWN, buff=0.1),
+            MathTex("P").next_to(P, UP, buff=0.1),
+        )
+        left_group = VGroup(line, A, B, C, P, labels)
+        left_group.move_to(left_box.get_center())
+        LayoutGuard.ensure_no_overlap(self, [left_group], left_box)
+        self.play(Create(line), FadeIn(A), FadeIn(B), FadeIn(C), FadeIn(P), FadeIn(labels))
+
+        # SEC_PROBLEM
+        step1 = SafeMathTex(r"모든 쌍: \frac{4\times3}{2}=6")
+        step1.move_to(right_box.get_left() + RIGHT * 0.2)
+        LayoutGuard.ensure_no_overlap(self, [step1], right_box)
+        self.play(Write(step1))
+        board.add_line(self, step1)
+
+        # SEC_WORK
+        step2 = SafeMathTex(r"ABC\text{ 한 직선} \Rightarrow 3-1=2 \text{ 중복}")
+        step2.move_to(right_box.get_left() + RIGHT * 0.2)
+        LayoutGuard.ensure_no_overlap(self, [step2], right_box)
+        self.play(Write(step2))
+        board.add_line(self, step2)
+
+        step3 = SafeMathTex(r"6-2=4")
+        step3.move_to(right_box.get_left() + RIGHT * 0.2)
+        LayoutGuard.ensure_no_overlap(self, [step3], right_box)
+        self.play(Write(step3))
+        board.add_line(self, step3)
+
+        step4 = SafeMathTex(r"AP, BP, CP, ABC")
+        step4.move_to(right_box.get_left() + RIGHT * 0.2)
+        LayoutGuard.ensure_no_overlap(self, [step4], right_box)
+        self.play(Write(step4))
+        board.add_line(self, step4)
+
+        # SEC_RESULT
+        answer = SafeMathTex(r"\boxed{4}")
+        answer.scale(2).move_to(ORIGIN)
+        self.play(Write(answer))
+        self.wait()


### PR DESCRIPTION
## Summary
- add `CountLines` scene showing how to count distinct lines determined by four points where three are collinear
- include layout helpers and rolling board per repository guidelines

## Testing
- `python -m py_compile Manim-code/middle-school-code/Ver1.1/count_lines.py`


------
https://chatgpt.com/codex/tasks/task_e_68b465bbbe3c832284ce38b20dda236e