### PR TITLE
Add Manim scenes solving linear equations with decimal coefficients

### DIFF
--- a/Manim-code/middle-school-code/Ver1.1/decimal_linear_equations.py
+++ b/Manim-code/middle-school-code/Ver1.1/decimal_linear_equations.py
@@ -1,0 +1,164 @@
+from manim import *
+import numpy as np
+
+MARGIN = 0.06
+GAP = 0.04
+LEFT_RATIO = 0.55
+RIGHT_RATIO = 0.45
+DEBUG = False
+
+class LayoutGuard:
+    @staticmethod
+    def ensure_no_overlap(scene, items, bounds_rect, min_scale=0.7, step_shift=0.15):
+        for m in items:
+            bbox = m.get_bounding_box()
+            rbb = bounds_rect.get_bounding_box()
+            dx, dy = 0, 0
+            if bbox[0][0] < rbb[0][0]:
+                dx = rbb[0][0] - bbox[0][0] + 0.02
+            if bbox[2][0] > rbb[2][0]:
+                dx = rbb[2][0] - bbox[2][0] - 0.02
+            if bbox[0][1] < rbb[0][1]:
+                dy = rbb[0][1] - bbox[0][1] + 0.02
+            if bbox[2][1] > rbb[2][1]:
+                dy = rbb[2][1] - bbox[2][1] - 0.02
+            if dx or dy:
+                m.shift(np.array([dx, dy, 0]))
+        def overlap(a, b):
+            Ab, Bb = a.get_bounding_box(), b.get_bounding_box()
+            return not (Ab[2][0] < Bb[0][0] or Bb[2][0] < Ab[0][0] or Ab[2][1] < Bb[0][1] or Bb[2][1] < Ab[0][1])
+        for i in range(len(items)):
+            for j in range(i + 1, len(items)):
+                a, b = items[i], items[j]
+                tries = 0
+                while overlap(a, b) and tries < 6:
+                    for m in (a, b):
+                        if m.width > bounds_rect.width * 0.9 and m.get_scale() > min_scale:
+                            m.scale(0.9)
+                    b.shift(RIGHT * step_shift + DOWN * step_shift)
+                    tries += 1
+
+class RollingBoard(VGroup):
+    def __init__(self, width, max_lines=3, line_gap=0.15, **kwargs):
+        super().__init__(**kwargs)
+        self.width = width
+        self.max_lines = max_lines
+        self.line_gap = line_gap
+        self.lines = []
+
+    def add_line(self, scene, mobj):
+        mobj.scale_to_fit_width(self.width)
+        if self.lines:
+            lowest = self.lines[-1]
+            mobj.next_to(lowest, DOWN, buff=self.line_gap).align_to(lowest, LEFT)
+        else:
+            mobj.to_edge(DOWN, buff=0.5).to_edge(RIGHT, buff=0.5)
+        self.lines.append(mobj)
+        scene.add(mobj)
+        if len(self.lines) > self.max_lines:
+            top = self.lines.pop(0)
+            scene.play(FadeOut(top, shift=UP * 0.2), run_time=0.3)
+            for k, line in enumerate(self.lines):
+                if k == 0:
+                    continue
+                line.next_to(self.lines[k - 1], UP, buff=self.line_gap).align_to(self.lines[k - 1], LEFT)
+
+def reserve_panels(scene):
+    frame = scene.camera.frame
+    W, H = frame.get_width(), frame.get_height()
+    left_x = -W / 2 + W * MARGIN
+    right_x = W / 2 - W * MARGIN
+    inner_w = W * (1 - 2 * MARGIN - GAP)
+    left_w = inner_w * LEFT_RATIO
+    right_w = inner_w * RIGHT_RATIO
+    left_box = Rectangle(width=left_w, height=H * (1 - 2 * MARGIN)).move_to(LEFT * (GAP / 2 * W) + LEFT * (right_w / 2)).shift(RIGHT * (W * MARGIN))
+    right_box = Rectangle(width=right_w, height=H * (1 - 2 * MARGIN)).to_edge(RIGHT, buff=W * MARGIN)
+    if DEBUG:
+        for r, color in [(left_box, YELLOW), (right_box, BLUE)]:
+            r.set_stroke(color, 1).set_fill(opacity=0)
+            scene.add(r.copy())
+    return left_box, right_box
+
+# Scene for equation (1)
+class Equation1Scene(Scene):
+    def construct(self):
+        left_box, right_box = reserve_panels(self)
+        board = RollingBoard(width=right_box.width * 0.95, max_lines=3)
+
+        number_line = NumberLine(x_range=[0, 4, 1], length=left_box.width * 0.9)
+        number_line.move_to(left_box.get_center())
+        x_val = ValueTracker(0)
+        dot = always_redraw(lambda: Dot(number_line.n2p(x_val.get_value()), color=RED))
+        LayoutGuard.ensure_no_overlap(self, [VGroup(number_line, dot)], left_box)
+        self.play(Create(number_line), FadeIn(dot))
+
+        # SEC_PROBLEM
+        eq = MathTex(r"0.2x-0.8=1.3x-3")
+        eq.move_to(right_box.get_left() + RIGHT * 0.2)
+        LayoutGuard.ensure_no_overlap(self, [eq], right_box)
+        self.play(Write(eq))
+        board.add_line(self, eq)
+
+        # SEC_GIVENS
+        eq1 = MathTex(r"2x-8=13x-30")
+        eq1.move_to(right_box.get_left() + RIGHT * 0.2)
+        LayoutGuard.ensure_no_overlap(self, [eq1], right_box)
+        self.play(Write(eq1))
+        board.add_line(self, eq1)
+
+        # SEC_WORK
+        eq2 = MathTex(r"22=11x")
+        eq2.move_to(right_box.get_left() + RIGHT * 0.2)
+        LayoutGuard.ensure_no_overlap(self, [eq2], right_box)
+        self.play(Write(eq2))
+        board.add_line(self, eq2)
+
+        eq3 = MathTex(r"x=2")
+        eq3.move_to(right_box.get_left() + RIGHT * 0.2)
+        LayoutGuard.ensure_no_overlap(self, [eq3], right_box)
+        self.play(Write(eq3))
+        board.add_line(self, eq3)
+
+        # SEC_RESULT
+        box = SurroundingRectangle(eq3, color=YELLOW)
+        self.play(Create(box), x_val.animate.set_value(2))
+        self.wait()
+
+# Scene for equation (2)
+class Equation2Scene(Scene):
+    def construct(self):
+        left_box, right_box = reserve_panels(self)
+        board = RollingBoard(width=right_box.width * 0.95, max_lines=3)
+
+        number_line = NumberLine(x_range=[0, 8, 1], length=left_box.width * 0.9)
+        number_line.move_to(left_box.get_center())
+        x_val = ValueTracker(0)
+        dot = always_redraw(lambda: Dot(number_line.n2p(x_val.get_value()), color=RED))
+        LayoutGuard.ensure_no_overlap(self, [VGroup(number_line, dot)], left_box)
+        self.play(Create(number_line), FadeIn(dot))
+
+        # SEC_PROBLEM
+        eq = MathTex(r"1.5(3-0.5x)+2=0.25x-1")
+        eq.move_to(right_box.get_left() + RIGHT * 0.2)
+        LayoutGuard.ensure_no_overlap(self, [eq], right_box)
+        self.play(Write(eq))
+        board.add_line(self, eq)
+
+        # SEC_GIVENS
+        eq1 = MathTex(r"6.5-0.75x=0.25x-1")
+        eq1.move_to(right_box.get_left() + RIGHT * 0.2)
+        LayoutGuard.ensure_no_overlap(self, [eq1], right_box)
+        self.play(Write(eq1))
+        board.add_line(self, eq1)
+
+        # SEC_WORK
+        eq2 = MathTex(r"7.5=x")
+        eq2.move_to(right_box.get_left() + RIGHT * 0.2)
+        LayoutGuard.ensure_no_overlap(self, [eq2], right_box)
+        self.play(Write(eq2))
+        board.add_line(self, eq2)
+
+        # SEC_RESULT
+        box = SurroundingRectangle(eq2, color=YELLOW)
+        self.play(Create(box), x_val.animate.set_value(7.5))
+        self.wait()


### PR DESCRIPTION
## Summary
- Implement helper classes for layout and rolling board
- Add scenes solving 0.2x-0.8=1.3x-3 and 1.5(3-0.5x)+2=0.25x-1 with final answers highlighted

## Testing
- `python -m py_compile Manim-code/middle-school-code/Ver1.1/decimal_linear_equations.py`
- `python -m manim -ql Manim-code/middle-school-code/Ver1.1/decimal_linear_equations.py Equation1Scene Equation2Scene` *(fails: No module named manim; attempted `pip install manim` but proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e3625e6c832299ae03d77dcb68fb